### PR TITLE
fixed relative imports

### DIFF
--- a/src/remembrall/__init__.py
+++ b/src/remembrall/__init__.py
@@ -1,10 +1,5 @@
 """Assistant bot for wizards of the academy.
 """
 
-# Standard library imports
-import sys
-
-sys.path.append('src/remembrall')
-
 # Version of wizards-remembrall package
 __version__ = "1.0.0"

--- a/src/remembrall/__main__.py
+++ b/src/remembrall/__main__.py
@@ -14,9 +14,9 @@ Version:
 
 - wizards-remembrall v1.0.0
 """
-from classes import Record
-from helpers import book_operations
-from helpers.data_upload import load_data, save_data
+from remembrall.classes import Record
+from remembrall.helpers import book_operations
+from remembrall.helpers.data_upload import load_data, save_data
 
 def parse_input(user_input: str) -> tuple:
     cmd, *args = user_input.split()

--- a/src/remembrall/classes/AddressBook.py
+++ b/src/remembrall/classes/AddressBook.py
@@ -1,8 +1,9 @@
 from collections import UserDict
-from .Record import Record
 from datetime import datetime, timedelta
-from helpers.constants import format
-from helpers.json_converter import to_json
+
+from .Record import Record
+from ..helpers.constants import format
+from ..helpers.json_converter import to_json
 
 class AddressBook(UserDict):
     def add_record(self, rec:Record):

--- a/src/remembrall/classes/Fields.py
+++ b/src/remembrall/classes/Fields.py
@@ -1,8 +1,9 @@
 import re
 from datetime import datetime
-from helpers.constants import format
+
 from .customErrors import ShortName, PhoneValidationError, DateFormatError
-from helpers.json_converter import to_json
+from ..helpers.constants import format
+from ..helpers.json_converter import to_json
 
 class Field:
     def __init__(self, value):

--- a/src/remembrall/classes/Record.py
+++ b/src/remembrall/classes/Record.py
@@ -1,7 +1,7 @@
-from classes import Name, Phone, Birthday
+from .Fields import Name, Phone, Birthday
 from .customErrors import PhoneValidationError
-from helpers.wrappers import input_error
-from helpers.json_converter import to_json
+from ..helpers.wrappers import input_error
+from ..helpers.json_converter import to_json
 
 class Record:
     def __init__(self, name: str):

--- a/src/remembrall/helpers/book_operations.py
+++ b/src/remembrall/helpers/book_operations.py
@@ -1,5 +1,5 @@
 from .wrappers import input_error
-from classes import AddressBook, Record
+from ..classes import AddressBook, Record
 
 @input_error
 def add_contact(args, book: AddressBook):

--- a/src/remembrall/helpers/data_upload.py
+++ b/src/remembrall/helpers/data_upload.py
@@ -1,7 +1,8 @@
 import pickle, json
-from classes import AddressBook
+
 from .book_operations import get_all_contacts
 from .wrappers import file_read_error
+from ..classes import AddressBook
 
 def save_data(book: AddressBook, filename="addressbook.pkl"):
     try:

--- a/src/remembrall/helpers/json_converter.py
+++ b/src/remembrall/helpers/json_converter.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, date
+
 from .constants import format
 
 def to_json(dict_data):

--- a/src/remembrall/helpers/wrappers.py
+++ b/src/remembrall/helpers/wrappers.py
@@ -1,5 +1,6 @@
 import re
-from classes.customErrors import ShortName, PhoneValidationError, DateFormatError
+
+from ..classes.customErrors import ShortName, PhoneValidationError, DateFormatError
 
 def input_error(func):
     def inner(*args, **kwargs):
@@ -53,4 +54,3 @@ def file_read_error(func):
         except Exception as error:
             print(f"File could not be read, {type(error)}, {error}")
     return inner
-


### PR DESCRIPTION
Python docs suggest two ways
1. Use relative paths (works for small projects like ours)
2. Use absolute path (starting from `remembrall` main package name)

Use Option 1 everywhere
Only in `__main__.py` VSCode Python code suggestion was not happy until I fixed by setting a full path for importing modules.